### PR TITLE
Do not emit metric, if delta = 0

### DIFF
--- a/client.go
+++ b/client.go
@@ -187,6 +187,9 @@ func (c client) IncrementCounter(name string) error {
 }
 
 func (c client) IncrementCounterWithDelta(name string, value uint64) error {
+	if value == 0 {
+		return nil;
+	}
 	c.client.EmitCounter(
 		name,
 		loggregator.WithCounterSourceInfo(c.sourceID, c.instanceID),

--- a/client_test.go
+++ b/client_test.go
@@ -106,6 +106,10 @@ var _ = Describe("DiegoLoggingClient", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 
+			assertEnvelopeBatchNotSent := func()  {
+				Consistently(testIngressServer.Receivers()).ShouldNot(Receive(&sender))
+			}
+ 
 			getEnvelopeBatch := func() *loggregator_v2.EnvelopeBatch {
 				if sender == nil {
 					Eventually(testIngressServer.Receivers()).Should(Receive(&sender))
@@ -174,6 +178,11 @@ var _ = Describe("DiegoLoggingClient", func() {
 					Expect(c.IncrementCounterWithDelta("its", 5)).To(Succeed())
 
 					assertEnvelopeSourceAndInstanceIDAreCorrect(getEnvelopeBatch())
+				})
+				It("does not emit metric if delta = 0", func() {
+					Expect(c.IncrementCounterWithDelta("its", 0)).To(Succeed())
+
+					assertEnvelopeBatchNotSent();
 				})
 			})
 


### PR DESCRIPTION
## Please provide the following information:
### What is this change about?
`IncrementCounterWithDelta` emits Counter metrics even if the delta parameter is 0

### What problem it is trying to solve?
When components emit Counter metrics with a Delta, they are not always checking if the Delta is 0. E.g. in route-emitter,
https://github.com/cloudfoundry/route-emitter/blob/ff7d1721626b869297a36ea3e1342109d4d1743b/emitter/nats_emitter.go#L81, https://github.com/cloudfoundry/route-emitter/blob/ff7d1721626b869297a36ea3e1342109d4d1743b/routehandlers/handler.go#L292

So what happens is that some customers try to start few thousands applications in parallel and we have 60 goroutes and we end up with 10000s of metrics where the delta is 0. This overflows the CPU usage on our Riemann instqnce, causing it to skip other metrics

We discovered that a big part of the metrics that are emitted are acutally with delta =0

### What is the impact if the change is not made?

On landscapes, where we are already using the largest VM type for Rieman we can no longer scale vertically and events are lost in such peak times

### How should this change be described in diego-release release notes?
IncrementCounterWithDelta will not emit a metric, if Delta is 0

### Please provide any contextual information.


### Tag your pair, your PM, and/or team!
@PlamenDoychev  
Thank you!
