### PR TITLE
client: use non-blocking dial for loggregator v2 ingress client

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	loggregator "code.cloudfoundry.org/go-loggregator/v9"
-	"google.golang.org/grpc"
 )
 
 type Config struct {
@@ -110,8 +109,10 @@ func newV2IngressClient(config Config) (IngressClient, error) {
 		opts = append(opts, loggregator.WithAddr(config.APIAddr()))
 	}
 
-	//lint:ignore SA1019 - we can't use grpc.WithContextDial until loggregator is updated for grpc.DialContext
-	opts = append(opts, loggregator.WithDialOptions(grpc.WithBlock(), grpc.WithTimeout(time.Second)))
+	// Non-blocking dial: connection is established lazily in the background.
+	// Loggregator may be briefly unavailable during BOSH upgrades; a blocking
+	// dial with a hard timeout caused rep to crash and Monit to restart it
+	// (~54s cycle) before the connection succeeded on retry.
 
 	c, err := loggregator.NewIngressClient(tlsConfig, opts...)
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -72,7 +72,7 @@ var _ = Describe("DiegoLoggingClient", func() {
 				testIngressServer.Stop()
 			})
 
-			It("returns an error when constructing the loggregator client", func() {
+			It("does not return an error when constructing the loggregator client (non-blocking)", func() {
 				metricsPort := 8080
 
 				_, err := client.NewIngressClient(client.Config{
@@ -85,7 +85,7 @@ var _ = Describe("DiegoLoggingClient", func() {
 					KeyPath:            metronClientKeyFile,
 					CertPath:           metronClientCertFile,
 				})
-				Expect(err).To(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 


### PR DESCRIPTION
## Summary

This PR addresses an issue where `rep` (and other jobs like `route_emitter` that use this client) can enter a Monit crash/restart cycle during stemcell rolls or full job restarts.

Previously, `NewIngressClient` used a blocking gRPC dial (`grpc.WithBlock()`) with a hard 1-second timeout. During BOSH's sequential start, if the `loggregator_agent` (local metron/ingress) was not yet listening when `rep` started, the dial would time out. This caused the process startup to fail, leading to a ~54s Monit crash/restart loop before the connection eventually succeeded on a subsequent retry.

This change moves to a **non-blocking / lazy connection model**. By removing `grpc.WithBlock()`, the gRPC connection is established in the background. This allows `rep` and other clients to stay up and complete their startup sequence while Loggregator finishes starting, significantly improving system stability during BOSH upgrades.

## Backward Compatibility
Breaking Change? **No**

This is not a breaking change. It modifies the internal connection establishment behavior to be non-blocking, but the external API of the client remains identical. 

- The client will now successfully initialize even if the loggregator agent is temporarily unavailable.
- Metrics emitted before the background connection is fully established are handled by the underlying gRPC library's buffering/retry mechanisms.
- This change should apply immediately to all deployments to improve resilience during upgrades.

## Test
The change was tested in a private diego-release running on a 50-cell foundation to ensure it works as coded.
